### PR TITLE
now the client idles and busy waits if he cannot connect to server

### DIFF
--- a/client/src/benchmark.rs
+++ b/client/src/benchmark.rs
@@ -1,4 +1,4 @@
-use crate::{CompleteCommand, BENCH_COUNT, CONCURRENT_CONNS};
+use crate::{idle_till_server_connection, CompleteCommand, BENCH_COUNT, CONCURRENT_CONNS};
 use rand::distributions::Alphanumeric;
 use rand::{thread_rng, Rng};
 use serde::{Deserialize, Serialize};
@@ -178,6 +178,8 @@ pub async fn perform_benchmark() {
 
     let mut up = 0;
     let mut handlers = Vec::with_capacity(count);
+    let addr = "127.0.0.1:8080";
+    idle_till_server_connection(addr).await;
     for e in entries {
         let key = e.0;
         let value = e.1;
@@ -191,7 +193,7 @@ pub async fn perform_benchmark() {
         let new_wrapper = start_wrapper.clone();
         let handler = tokio::spawn(async move {
             // sleep(core::time::Duration::from_millis(100)).await;
-            perform_sequence("127.0.0.1:8080", key, value, ass_conn_mutex, new_wrapper).await
+            perform_sequence(addr, key, value, ass_conn_mutex, new_wrapper).await
         });
         handlers.push(handler);
     }

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -161,7 +161,7 @@ async fn idle_till_server_connection(addr: &str) {
                 break;
             }
             Err(err) => match err.kind() {
-                std::io::ErrorKind::ConnectionRefused => {
+                std::io::ErrorKind::ConnectionRefused | std::io::ErrorKind::ConnectionReset => {
                     if !failed_connection_before {
                         println!("Waiting for server to start...");
                         failed_connection_before = true;


### PR DESCRIPTION
Added a function `idle_till_server_connection` which tries to connect to the server.

If it manages to do so everything continues like before. Otherwise if the error was of the type ConnectionRefused, which indicates that the server is not up yet, it busy waits and tries again. If the error had another type it panics and prints out the error type.