### PR TITLE
Dockerize rust

### DIFF
--- a/Rust/Dockerfile
+++ b/Rust/Dockerfile
@@ -1,0 +1,10 @@
+FROM rust:1.59 as builder
+WORKDIR /usr/src/myapp
+COPY . .
+RUN sh -c 'if [ $(uname -m) = "aarch64" ]; then rustup target add aarch64-unknown-linux-musl; else rustup target add x86_64-unknown-linux-musl; fi'
+RUN sh -c 'if [ $(uname -m) = "aarch64" ]; then cargo install --path . --target aarch64-unknown-linux-musl; else cargo install --path . --target x86_64-unknown-linux-musl; fi'
+
+FROM alpine
+COPY --from=builder /usr/local/cargo/bin/server-bench /usr/local/bin/server-bench
+EXPOSE 8080
+CMD ["server-bench"]


### PR DESCRIPTION
I added a Dockerfile for Rust which builds and runs in different containers.

## Usage

To build the image execute:

`docker build -t bench-rust .`

Then you need to create a container:

`docker create --name bench-rust -p 8080:8080 bench-rust`

Then you can start the container like this:

`docker start bench-rust`

For stopping and removing the container execute the following line of code:

`docker stop bench-rust && docker rm bench-rust`