### PR TITLE
Dockerfile for Python and Pypy

### DIFF
--- a/Python/Dockerfile
+++ b/Python/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:alpine
+
+COPY . .
+
+EXPOSE 8080
+
+CMD ["python3", "main.py"]

--- a/Python/Dockerfile-pypy
+++ b/Python/Dockerfile-pypy
@@ -1,0 +1,7 @@
+FROM pypy:latest
+
+COPY . .
+
+EXPOSE 8080
+
+CMD ["pypy3", "main.py"]


### PR DESCRIPTION
Dockerfiles for Python.

Includes Dockerfile with Python3 and Pypy. 

There is no Pypy image with alpine, so it's not used.