### PR TITLE
Spec revamp

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -154,6 +154,7 @@ GETDUMP
 ## DUMPINTERVAL
 
 Upon receiving this command the server shall cancel the next scheduled [recurring dump](#recurring-dumps), change the interval at which the recurring dumps are performed to the given `interval`, and schedule the next recurring dump to happen after the new interval has elapsed once.
+The server shall respond with `DONE`.
 
 ```
 DUMPINTERVAL interval
@@ -163,7 +164,9 @@ Argument `interval` must be a duration formatted as specified in the [duration c
 
 ## SETTTL
 
-The server shall perform a `SET` command immediately and respond with the answer specified in [SET](#set). After `duration`, the server shall remove the `key`-`value` pair from the hashmap. The timer shall start running immediately after the response of `SET` was send (+/- 1s).
+The server shall perform a `SET` command immediately and respond with the answer specified in [SET](#set). After `duration`, the server shall execute a `DEL` operation on `key`. The timer shall start running immediately after the response of `SET` was send (+/- 1s).
+
+`GET`, `SET` or `DEL` operations happening while the TTL timer is running have no additional effect: They shall behave like normal. After the timer runs out, `key` shall be deleted if it still exists.
 
 ```
 SETTTL key value duration
@@ -185,7 +188,7 @@ The `UPLOAD` protocol consists of multiple steps (every message is delimited by 
 
 1. The server shall respond with `READY` as soon it is ready to receive the data.
 2. The client streams `size` bytes of binary data to the server.
-3. The server shall respond with a [SHA-512](https://csrc.nist.gov/publications/detail/fips/180/4/final) hash of the data that was streamed in hex.
+3. The server shall respond with a [SHA-512](https://csrc.nist.gov/publications/detail/fips/180/4/final) hash of the data that was streamed as a hex string (like the output of `sha512sum`).
 4. The client answers with either `OK` or `ERROR`. If the response is `OK`, the server should do nothing. If it is `ERROR`, the server shall delete the file just created.
 
 If a file named `key` is already present, the server shall overwrite it.
@@ -205,7 +208,7 @@ The `DOWNLOAD` protocol consists of multiple steps (every message is delimited b
 1. If the file named `key` exists, the server shall respond with the size of the file named `key` in bytes and with `not found` otherwise.
 2. The client responds with `READY` as soon it is ready to receive the transmission.
 3. The server shall stream the binary data from the file named `key` to the client.
-4. The client responds with a [SHA-512](https://csrc.nist.gov/publications/detail/fips/180/4/final) hash of the data that was streamed in hex.
+4. The client responds with a [SHA-512](https://csrc.nist.gov/publications/detail/fips/180/4/final) hash of the data that was streamed as a hex string (like the output of `sha512sum`).
 5. If the hash from the client matches with the hash the server calculated, the server shall respond with `OK`. Otherwise it shall respond with `ERROR`.
 
 ## REMOVE

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,16 +1,16 @@
 # Specification
 
-Each server impementation has to provide basic functionality of a TCP based Redis-like key value store.
+Each server implementation shall provide basic functionality of a TCP based Redis-like key-value store.
 
 ## Commands
 
-Commands are sent via Tcp. Multiple commands can be issued over one connection. The connection is closed by the client at some point. Every command is delimited by a new line character. Every response is delimited by a new line. Commands and responses are UTF-8 encoded.
+Commands are sent via TCP. Multiple commands can be issued over one connection. The connection is closed by the client at some point. Every command is delimited by a new line character. Every response is delimited by a new line. Commands and responses are UTF-8 encoded.
 
-Every part of the command has to be validated. That includes command names, keys, values and durations, as well as the number of arguments. However the server should allow leading and trailing whitespace.
+Every part of the command has to be validated. That includes command names, keys, values and durations, as well as the number of arguments. However the server shall allow leading and trailing horizontal whitespace, i.e. space (`U+0020`) and tab (`U+0009`).
 
-The commands with arguments should be checked for the right amount of seperating spaces (one between each pair of parts) and be rejected otherwise.
+The commands with arguments shall be checked for the right amount of separating spaces (exactly one between each pair of parts) and shall be rejected otherwise.
 
-If the sent line does not match any of the specified commands, the server should respond with "`invalid command`".
+If the sent line does not match any of the specified commands, the server shall respond with "`invalid command`".
 
 Essential commands:
 
@@ -43,101 +43,101 @@ Maintenance commands:
 
 ## Recurring dumps
 
-The server should run the NEWDUMP command in a configurable interval (changed by the `DUMPINTERVAL` command) and store the result internally. The initial interval is 10s. The server should start the interval immediately and make the first dump the first time the interval is reached.
+The server shall run the `NEWDUMP` command periodically with a configurable interval (changed by the `DUMPINTERVAL` command) and store the result internally. The initial interval at startup shall be set to 10s. The server shall schedule the first recurring dump immediately after starting up, such that the first dump is performed after the interval has elapsed once.
 
-### Parts
+## Parts
 
-#### Key / Value
+### Key / Value
 
-Every key and has to match the following Regex completely:
+Every key and every value must match the following Regex completely:
 ```regexp
 [a-zA-Z0-9]+
 ```
 
-The server **has to verify** that key and value match the format and reject the command otherwise. Note that the verification does not have to be performed with Regex.
+For each argument following this convention, the server **shall verify** that key and value match the format and reject the command otherwise. Note that the verification does not have to be performed with Regex.
 
-#### Duration
+### Duration
 
-Every duration has to match with the following Regex completely:
+Every duration must match with the following Regex completely:
 ```regexp
 ([0-9][0-9])h-([0-5][0-9])m-([0-5][0-9])s
 ```
 Example: `24h-33m-24s` corresponds to 24 hours, 33 minutes and 24 seconds.
 
-#### JSON Encoded DUMP
+### JSON Encoded DUMP
 
 A dump has a specific format:
 
-At the top level it is a JSON Array, where each element represents a key-value pair in the Hash Map. A dump with one entry looks like this:
+At the top level it is a JSON Array, where each element represents a key-value pair in the key-value store. A dump with one entry looks like this:
 
 ```json
 [{"key":"key","associated_value":{"value":"value","timestamp":"2022-04-07T14:27:41.635779Z"}}]
 ```
 
-The meaning of key and value should be obvious. The timestamp has to be a ISO 8601 formatted timestamp with 6 fraction digits. The time zone is irrelevant. The timestamp represents the moment the key / value pair was created or when it was overwritten (whatever happend later).
+The meaning of key and value should be obvious. The timestamp must be a `ISO 8601` formatted timestamp with 6 fraction digits, i.e. with microsecond precision. The time zone is irrelevant. The timestamp represents the moment the key / value pair was created or when it was overwritten (whichever happened last).
 
-### GET
+## GET
 
-The server should respond with the value associated with this key, if it exits. If the value does not exist, the server should respond with `not found`.
+The server shall respond with the value associated with the given key, if there is one. If there is no value associated with this key, the server shall respond with `not found`.
 
 ```
 GET key
 ```
 
-`key` has to follow the [Key / Value convention](SPEC.md#key--value).
+Argument `key` must follow the [Key / Value convention](SPEC.md#key--value).
 
 
-### SET
+## SET
 
-The server should respond with the value formerly associated with this key if it exists. If the value did not exist before, the server should respond with `not found`.
+The server shall respond with the value formerly associated with the given key if there was one. If there was no value associated with this key before, the server shall respond with `not found`.
 
-This command stores the `value` under the given `key`.
+Upon receiving this command the server shall store the `value` under the given `key`, replacing the previous value if there was one.
 
 ```
 SET key value
 ```
 
-`key` and `value` have to follow the [Key / Value convention](SPEC.md#key--value).
+Arguments `key` and `value` must follow the [Key / Value convention](SPEC.md#key--value).
 
-### DEL
+## DEL
 
-The server should respond with the value formerly associated with this key if it exists. If the value did not exist before, the server should respond with `not found`.
+The server shall respond with the value formerly associated with this key if there was one. If there was no value associated with this key before, the server shall respond with `not found`.
 
-This command deletes the associated `key` `value` pair if it exists.
+Upon receiving this command the server shall delete the associated `key`-`value` pair if it exists.
 
 ```
 DEL key
 ```
 
-`key` has to follow the [Key / Value convention](SPEC.md#key--value).
+Argument `key` must follow the [Key / Value convention](SPEC.md#key--value).
 
-### GETC
+## GETC
 
-Returns the number of performed `GET` commands. (The counter should be atomic)
+The server shall respond with the number of performed `GET` commands since the startup or the last reset of the server (whichever happened last). The counter should be atomic.
 
 ```
 GETC
 ```
 
-### SETC
+## SETC
 
-Returns the number of performed `SET` commands. (The counter should be atomic)
+The server shall respond with the number of performed `SET` commands since the startup or the last reset of the server (whichever happened last). The counter should be atomic.
 
 ```
 SETC
 ```
 
-### DELC
+## DELC
 
-Returns the number of performed `DEL` commands. (The counter should be atomic)
+The server shall respond with the number of performed `DEL` commands since the startup or the last reset of the server (whichever happened last). The counter should be atomic.
 
 ```
 DELC
 ```
 
-### NEWDUMP
+## NEWDUMP
 
-Returns a snaphsot of the key-value store as a [JSON Encoded DUMP](SPEC.md#json-encoded-dump). However the Snapshot does not need to be a hard clone of the hash map, it is allowed to walk the hashmap while other operations continue (the Go implementation behaves like this).
+The server shall respond with a snapshot of the key-value store as a [JSON Encoded DUMP](SPEC.md#json-encoded-dump). However, the snapshot does not need to be a hard clone of the hash map, it is allowed to walk the hashmap while other operations continue (the Go implementation behaves like this).
 
 ```
 NEWDUMP
@@ -145,53 +145,52 @@ NEWDUMP
 
 ### GETDUMP
 
-Returns the latest snapshot created by the [`NEWDUMP`](SPEC.md#newdump) command by the [recuring dump](SPEC.md#recurring-dumps). If no dump is present, perform [`NEWDUMP`](SPEC.md#newdump) and return the result.
+The server shall respond with the latest snapshot created by the [`NEWDUMP`](SPEC.md#newdump) command or by a [recurring dump](SPEC.md#recurring-dumps) (whichever was created last) as a [JSON Encoded DUMP](SPEC.md#json-encoded-dump). If no dump is present, the server shall perform [`NEWDUMP`](SPEC.md#newdump) and return the result.
 
 ```
 GETDUMP
 ```
 
-### DUMPINTERVAL
+## DUMPINTERVAL
 
-This command changes the interval at which dumps are performed by the [recurring dumper](#recurring-dumps). There should only be one dumper running at any point in time.
-Upon receiving `DUMPINTERVAL`, the server should cancel the existing dumping interval and schedule the next recurring dump to happen after the new interval has elapsed once.
+Upon receiving this command the server shall cancel the next scheduled [recurring dump](#recurring-dumps), change the interval at which the recurring dumps are performed to the given `interval`, and schedule the next recurring dump to happen after the new interval has elapsed once.
 
 ```
 DUMPINTERVAL interval
 ```
 
-`interval` is a duration formatted as specified in the [duration convention](SPEC.md#duration).
+Argument `interval` must be a duration formatted as specified in the [duration convention](SPEC.md#duration).
 
-### SETTTL
+## SETTTL
 
-The server should perform a `SET` command immediately and respond with the answer specified in [SET](#set). After `duration`, the server should remove the `key-value` pair from the hashmap. The timer should start running immediately after the response of `SET` was send (+/- 1s).
+The server shall perform a `SET` command immediately and respond with the answer specified in [SET](#set). After `duration`, the server shall remove the `key`-`value` pair from the hashmap. The timer shall start running immediately after the response of `SET` was send (+/- 1s).
 
 ```
 SETTTL key value duration
 ```
 
-`key` and `value` have to follow the [Key / Value conventeion](#key--value) and duration the [duration convention](#duration).
+Arguments `key` and `value` must follow the [Key / Value convention](#key--value) and argument duration the [duration convention](#duration).
 
-### UPLOAD
+## UPLOAD
 
-This command uploads binary data to the server. It should be stored in a file inside a temporary directory and be removed when the server is shut down.
+This command uploads binary data to the server. It shall be stored in a file named `key` inside a temporary directory, which shall be deleted when the [REMOVE](#remove) command is performed with this `key` or when is the server is shut down (whichever happens first).
 
 ```
 UPLOAD key size
 ```
 
-`key` has to follow the [Key / Value convention](#key--value) and `size` is an unsigned 64-bit integer.
+Argument `key` must follow the [Key / Value convention](#key--value) and `size` is an unsigned 64-bit integer.
 
-The `UPLOAD` protocol consists of multiple steps (Every message is delimited by a newline):
+The `UPLOAD` protocol consists of multiple steps (every message is delimited by a newline):
 
-1. The server sends with `READY` as soon it is ready to receive the data.
-2. The client streams `size` bytes of binary data.
-3. The server responds with a [SHA-512](https://csrc.nist.gov/publications/detail/fips/180/4/final) hash of the data that was streamed in hex.
-4. The client awnsers with `OK` or `ERROR`. If the response is `OK`, the server does nothing. If it is `ERROR`, the server should delete the file just created.
+1. The server shall respond with `READY` as soon it is ready to receive the data.
+2. The client streams `size` bytes of binary data to the server.
+3. The server shall respond with a [SHA-512](https://csrc.nist.gov/publications/detail/fips/180/4/final) hash of the data that was streamed in hex.
+4. The client answers with either `OK` or `ERROR`. If the response is `OK`, the server should do nothing. If it is `ERROR`, the server shall delete the file just created.
 
-If there is already a file present with this key, the server should overwrite it.
+If a file named `key` is already present, the server shall overwrite it.
 
-### DOWNLOAD
+## DOWNLOAD
 
 This command downloads previously saved binary data from the server.
 
@@ -199,30 +198,30 @@ This command downloads previously saved binary data from the server.
 DOWNLOAD key
 ```
 
-`key` has to follow the [Key / Value convention](#key--value).
+Argument `key` must follow the [Key / Value convention](#key--value).
 
-The `DOWNLOAD` protocol consists of multiple steps (Every message is delimited by a newline):
+The `DOWNLOAD` protocol consists of multiple steps (every message is delimited by a newline):
 
-1. If the file `key` exists, the server sends the size of the file stored under `key` in bytes and `not found` otherwise.
+1. If the file named `key` exists, the server shall respond with the size of the file named `key` in bytes and with `not found` otherwise.
 2. The client responds with `READY` as soon it is ready to receive the transmission.
-3. The server streams the binary data from the file `key` to the client.
+3. The server shall stream the binary data from the file named `key` to the client.
 4. The client responds with a [SHA-512](https://csrc.nist.gov/publications/detail/fips/180/4/final) hash of the data that was streamed in hex.
-5. If the hash from the client matches with the hash the server calculated, the server responds with `OK` or `ERROR` otherwise.
+5. If the hash from the client matches with the hash the server calculated, the server shall respond with `OK`. Otherwise it shall respond with `ERROR`.
 
-### REMOVE
+## REMOVE
 
-If a file named `key` exists, the server should delete it and respond with `DONE`.
-Otherwise, the server should respond with `not found`
+If a file named `key` exists, the server shall delete it and respond with `DONE`.
+Otherwise, the server shall respond with `not found`
 
 ```
 REMOVE key
 ```
 
-`key` has to follow the [Key / Value convention](#key--value).
+Argument `key` must follow the [Key / Value convention](#key--value).
 
-### RESET
+## RESET
 
-The server should discard any state and reset itself to the state it had when it was started. It should then respond with `DONE`.
+The server shall discard any state and reset itself to the state it had when it was started. It shall then respond with `DONE`.
 
 ```
 RESET

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,18 +1,18 @@
 # Specification
 
-The server has to implement the basic functionality of a TCP based Redis-like key value store. It is important that the operations happen **in Order** without bad-interleaving.
+Each server impementation has to provide basic functionality of a TCP based Redis-like key value store.
 
 ## Commands
 
-Commands are sent via Tcp. Multiple commands can be issued over one connection. The connection is closed by the client. Every command is delimited by a new line character. Every response is delimited by a new line. Commands and responses are UTF-8 encoded.
+Commands are sent via Tcp. Multiple commands can be issued over one connection. The connection is closed by the client at some point. Every command is delimited by a new line character. Every response is delimited by a new line. Commands and responses are UTF-8 encoded.
 
-Every part of the command has to be checked **in total**. That means validity of keys, values and durations, as well as if the right number of arguments were supplied. However the server should allow leading and trailing whitespace.
+Every part of the command has to be validated. That includes command names, keys, values and durations, as well as the number of arguments. However the server should allow leading and trailing whitespace.
 
-The commands with arguments should be checked for the right amount of seperating spaces (one between parts) and get rejected otherwise.
+The commands with arguments should be checked for the right amount of seperating spaces (one between each pair of parts) and be rejected otherwise.
 
-If the sent line is not one of the commands specified, respond with "`invalid command`".
+If the sent line does not match any of the specified commands, the server should respond with "`invalid command`".
 
-The essential commands are:
+Essential commands:
 
 * [GET](SPEC.md#get)
 * [SET](SPEC.md#set)
@@ -21,222 +21,216 @@ The essential commands are:
 * [SETC](SPEC.md#setc)
 * [DELC](SEPC.md#delc)
 
-The dumping commands are:
+Dumping commands:
 
 * [NEWDUMP](#newdump)
 * [GETDUMP](#getdump)
 * [DUMPINTERVAL](#dumpinterval)
 
-The delayed commands are:
+Delay commands:
 
 * [SETTTL](#setttl)
 
-The heavy load commans are:
+Heavy load commands:
 
 * [UPLOAD](#upload)
 * [DOWNLOAD](#download)
 * [REMOVE](#remove)
 
+Maintenance commands:
+
+* [RESET](#reset)
+
 ## Recurring dumps
 
-The server should run the NEWDUMP command in a changing interval (changed by the `DUMPINTERVAL` command) and store the result internally. The initial interval is 10s.
+The server should run the NEWDUMP command in a configurable interval (changed by the `DUMPINTERVAL` command) and store the result internally. The initial interval is 10s. The server should start the interval immediately and make the first dump the first time the interval is reached.
 
 ### Parts
 
 #### Key / Value
 
-Every key and has to match **in total** with the following Regex:
+Every key and has to match the following Regex completely:
 ```regexp
 [a-zA-Z0-9]+
 ```
 
-The server **has to verify** that key and value correspond to the requirenment and reject the command otherwise. Although the verification doesn't have to performed with Regex.
+The server **has to verify** that key and value match the format and reject the command otherwise. Note that the verification does not have to be performed with Regex.
 
 #### Duration
 
-Every duration has to match **in total** with the following Regex:
+Every duration has to match with the following Regex completely:
 ```regexp
-([0-9][0-9])h-([0-9][0-9])m-([0-9][0-9][0-9])s
+([0-9][0-9])h-([0-5][0-9])m-([0-5][0-9])s
 ```
-The extraction of hours, minutes and seconds should be obvious.
+Example: `24h-33m-24s` corresponds to 24 hours, 33 minutes and 24 seconds.
 
 #### JSON Encoded DUMP
 
-A dump has to be returned in the specified way.
+A dump has a specific format:
 
-At the top level it has to be a JSON Array, with each element representing a key-value pair in the Hash Map. Each entry has to be formed like the following example:
+At the top level it is a JSON Array, where each element represents a key-value pair in the Hash Map. A dump with one entry looks like this:
 
 ```json
-{"key":"key","associated_value":{"value":"value","timestamp":"2022-04-07T14:27:41.635779Z"}}
+[{"key":"key","associated_value":{"value":"value","timestamp":"2022-04-07T14:27:41.635779Z"}}]
 ```
 
-The definition of key and value should be obvious. The timestamp has to be a ISO 8601 formatted timestamps with at least 10^-6 seconds precision. The time zone is irrelevant. The timestamp represents the moment the key / value pair was created or when it was overwritten (whatever happend later).
+The meaning of key and value should be obvious. The timestamp has to be a ISO 8601 formatted timestamp with 6 fraction digits. The time zone is irrelevant. The timestamp represents the moment the key / value pair was created or when it was overwritten (whatever happend later).
 
 ### GET
 
-The GET command is specified as following
+The server should respond with the value associated with this key, if it exits. If the value does not exist, the server should respond with `not found`.
 
 ```
 GET key
 ```
 
-where `key` has to follow the [Key / Value convention](SPEC.md#key--value).
+`key` has to follow the [Key / Value convention](SPEC.md#key--value).
 
-The server has to respond with the value associated with this key, if it exits. If the value doesn't exist respond with `not found`.
 
 ### SET
 
-The SET command is specified as following
+The server should respond with the value formerly associated with this key if it exists. If the value did not exist before, the server should respond with `not found`.
+
+This command stores the `value` under the given `key`.
 
 ```
 SET key value
 ```
 
-where `key` and `value` have to follow the [Key / Value convention](SPEC.md#key--value).
-
-The server has to respond with the value formerly associated with this key, if it exists. If the value doesn't exist respond with `not found`.
-
-This command stores the `value` with the corresponding `key`.
+`key` and `value` have to follow the [Key / Value convention](SPEC.md#key--value).
 
 ### DEL
 
-The DEL command is specified as following
+The server should respond with the value formerly associated with this key if it exists. If the value did not exist before, the server should respond with `not found`.
+
+This command deletes the associated `key` `value` pair if it exists.
 
 ```
 DEL key
 ```
 
-where `key` has to follow the [Key / Value convention](SPEC.md#key--value).
-
-The server has to respond with the value formerly associated with this key, if it exists. If the value doesn't exist respond with `not found`.
-
-This command deletes the associated `key` `value` pair if it exists.
+`key` has to follow the [Key / Value convention](SPEC.md#key--value).
 
 ### GETC
 
-The GETC command is specified as following
+Returns the number of performed `GET` commands. (The counter should be atomic)
 
 ```
 GETC
 ```
 
-Returns the number of performed `GET` commands. (The counter should be atomic)
-
 ### SETC
 
-The SETC command is specified as following
+Returns the number of performed `SET` commands. (The counter should be atomic)
 
 ```
 SETC
 ```
 
-Returns the number of performed `SET` commands. (The counter should be atomic)
-
 ### DELC
 
-The DELC command is specified as following
+Returns the number of performed `DEL` commands. (The counter should be atomic)
 
 ```
 DELC
 ```
 
-Returns the number of performed `DEL` commands. (The counter should be atomic)
-
 ### NEWDUMP
 
-The NEWDUMP command is specified as following
+Returns a snaphsot of the key-value store as a [JSON Encoded DUMP](SPEC.md#json-encoded-dump). However the Snapshot does not need to be a hard clone of the hash map, it is allowed to walk the hashmap while other operations continue (the Go implementation behaves like this).
 
 ```
 NEWDUMP
 ```
 
-Returns a snaphsot of the key-value store JSON encoded. However the Snapshot doesn't need to be a hard clone of the hole hash map. It's allowed to walk the hashmap while other operations continue (the Go implementation implements this behaviour).
-
-The return string should be a [JSON Encoded DUMP](SPEC.md#json-encoded-dump) (obviously the just created dump).
-
 ### GETDUMP
 
-The GETDUMP command is specified as following
+Returns the latest snapshot created by the [`NEWDUMP`](SPEC.md#newdump) command by the [recuring dump](SPEC.md#recurring-dumps). If no dump is present, perform [`NEWDUMP`](SPEC.md#newdump) and return the result.
 
 ```
 GETDUMP
 ```
 
-Returns the latest snapshot created by the latest [`NEWDUMP`](SPEC.md#newdump) command or a dump created by the [recuring dump](SPEC.md#recurring-dumps). If no dump is present, perform [`NEWDUMP`](SPEC.md#newdump) and return the result.
-
 ### DUMPINTERVAL
 
-The DUMPINTERVAL command is specified as following
+This command changes the interval at which dumps are performed by the [recurring dumper](#recurring-dumps). There should only be one dumper running at any point in time.
+Upon receiving `DUMPINTERVAL`, the server should cancel the existing dumping interval and schedule the next recurring dump to happen after the new interval has elapsed once.
 
 ```
 DUMPINTERVAL interval
 ```
 
-where `interval` is a duration formatted like the standard [duration convention](SPEC.md#duration).
-
-This command changes the interval at which dumps are performed by the [recurring dumper](#recurring-dumps). There should be running **only one dumper** at any point of time.
+`interval` is a duration formatted as specified in the [duration convention](SPEC.md#duration).
 
 ### SETTTL
 
-The SETTTL command is specified as following
+The server should perform a `SET` command immediately and respond with the answer specified in [SET](#set). After `duration`, the server should remove the `key-value` pair from the hashmap. The timer should start running immediately after the response of `SET` was send (+/- 1s).
 
 ```
 SETTTL key value duration
 ```
 
-where `key` and `value` conform to the [Key / Value conventeion](#key--value) and duration conforms to the [duration convention](#duration).
-
-The server should perform a `SET` command immediatly and respond with the awnsers specified in [SET](#set). After `duration` the server should remove the `key` from the hashmap. The time should start running at about the time (+/- 1s) when the response of `SET` was send.
+`key` and `value` have to follow the [Key / Value conventeion](#key--value) and duration the [duration convention](#duration).
 
 ### UPLOAD
 
-The UPLOAD command is specified as following
+This command uploads binary data to the server. It should be stored in a file inside a temporary directory and be removed when the server is shut down.
 
 ```
 UPLOAD key size
 ```
 
-where `key` conforms to the [Key / Value convention](#key--value) and `size` is an unsigned long long (the C type) without leading zeros.
+`key` has to follow the [Key / Value convention](#key--value) and `size` is an unsigned 64-bit integer.
 
-The server should respond with `READY` (with trailing newline) as soon it's ready.
+The `UPLOAD` protocol consists of multiple steps (Every message is delimited by a newline):
 
-After that the client streams binary data with `size` bytes. `size` always exceeds the amount of memory available to the server, thus a storage in memory is not feasible. Instead a storage in a file is strongly suggested.
+1. The server sends with `READY` as soon it is ready to receive the data.
+2. The client streams `size` bytes of binary data.
+3. The server responds with a [SHA-512](https://csrc.nist.gov/publications/detail/fips/180/4/final) hash of the data that was streamed in hex.
+4. The client awnsers with `OK` or `ERROR`. If the response is `OK`, the server does nothing. If it is `ERROR`, the server should delete the file just created.
 
-After the transmission is completed the server should respond with a base64 encoded [SHA-512/256](https://csrc.nist.gov/publications/detail/fips/180/4/final) hash of the data that was streamed.
-
-The client now awnsers with `OK` or `ERROR` (with trailing newline). If the response is `OK`, everything is done here. If it's `ERROR` delete the file just created, everything is done here.
-
-If there is already a file present with this key, delete it.
+If there is already a file present with this key, the server should overwrite it.
 
 ### DOWNLOAD
 
-The DOWNLOAD command is specified as following
+This command downloads previously saved binary data from the server.
 
 ```
 DOWNLOAD key
 ```
 
-where `key` conforms to the [Key / Value convention](#key--value).
+`key` has to follow the [Key / Value convention](#key--value).
 
-The server should respond with the size of the file stored under `key` with a trailing newline or with `not found` otherwise.
+The `DOWNLOAD` protocol consists of multiple steps (Every message is delimited by a newline):
 
-The client responds with `READY` (with trailing newline) as soon it's ready to receive the transmission.
-
-The server now streams the binary data found at `key` to the client.
-
-The client responds with a base64 encoded [SHA-512/256](https://csrc.nist.gov/publications/detail/fips/180/4/final) hash of the data that was streamed.
-
-If the hash of the client matches up with the hash the server calculated, return `OK`. Return `ERROR` otherwise.
-
+1. If the file `key` exists, the server sends the size of the file stored under `key` in bytes and `not found` otherwise.
+2. The client responds with `READY` as soon it is ready to receive the transmission.
+3. The server streams the binary data from the file `key` to the client.
+4. The client responds with a [SHA-512](https://csrc.nist.gov/publications/detail/fips/180/4/final) hash of the data that was streamed in hex.
+5. If the hash from the client matches with the hash the server calculated, the server responds with `OK` or `ERROR` otherwise.
 
 ### REMOVE
 
-The REMOVE command is specified as following
+If a file named `key` exists, the server should delete it and respond with `DONE`.
+Otherwise, the server should respond with `not found`
 
 ```
 REMOVE key
 ```
 
-where `key` conforms to the [Key / Value convention](#key--value).
+`key` has to follow the [Key / Value convention](#key--value).
 
-The server should delete the file associated with `key` if present and return `not found` otherwise.
+### RESET
+
+The server should discard any state and reset itself to the state it had when it was started. It should then respond with `DONE`.
+
+```
+RESET
+```
+
+In particular, the server has to reset:
+
+- The key-value store
+- The dump (stored dump & interval)
+- Stored files
+- The `GET`, `SET` and `DEL` counters


### PR DESCRIPTION
This PR adresses the issues #64, #65, #66 and #67.

I fixed some typos and restructured the spec a bit, while adding in the suggestions of the mentioned issues.

What I changed:

- The `duration` convention now makes sense (resolves #67)
- The `DUMPINTERVAL` command is now strict (resolves #65) 
- Added a note that temporary files should be removed upon server shutdown
- Changed the hash function to SHA512 (resolves #66)
- `REMOVE` and `DUMPINTERVAL` now respond with `DONE`, to have a testable confirmation
- Added `RESET`, which resets the server to its initial state and responds with `DONE` (replaces #64)
- `SETTTL` shall now execute `SET` and `DEL` operations (meaning follow their spec and increment the respective counters)