### PR TITLE
Close the connection on fail

### DIFF
--- a/Deno/src/server.ts
+++ b/Deno/src/server.ts
@@ -21,6 +21,7 @@ async function handleConn(conn: Deno.Conn) {
         await conn.write(messages.invalidCommand);
       }
     } catch {
+      conn.close();
       break;
     }
   }


### PR DESCRIPTION
Closes the connection if an error occurs somewhere underneath.
This is necessary since Deno don't seems to have a notion of closing unused or shutdown connections fast enough.

See denoland/deno#15281 for details on how we discovered this.

The issue probably only arrises when a lot of connections are not properly closed.